### PR TITLE
Add font option and remove filetype option

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@
       <div class="color-bg-default border rounded-2 p-3 mt-3">
         <div class="created-url border color-border-muted rounded-1 color-bg-subtle p-2 text-mono f6 wb-break-word">
           https://fakeimg.pl/<span id="width">600</span><span id="height">x400</span><span
-            id="bgcolour"></span><span id="textcolour"></span><span id="filetype"></span><span id="string"><span id="font"></span></span>
+            id="bgcolour"></span><span id="textcolour"></span><span id="filetype"></span><span id="string"></span><span id="font"></span>
         </div>
 
         <div class="d-flex flex-wrap mt-2">

--- a/index.html
+++ b/index.html
@@ -86,6 +86,18 @@
           <input class="flex-1 form-control input--colour" name="input-textcolour" id="input-textcolour" type="text" value="#909090">
         </div>
 
+        <div class="d-flex flex-items-center mt-3">
+          <label for="input-font" class="flex-1 mr-5">Font</label>
+          <select name="input-font" id="input-font" class="form-select flex-1" aria-label="Font">
+            <option value="bebas">Bebas</option>
+            <option value="lobster">Lobster</option>
+            <option value="museo">Museo</option>
+            <option value="noto">Noto Sans</option>
+            <option value="noto-serif">Noto Serif</option>
+            <option value="yanone" selected>Yanone</option>
+          </select>
+        </div>
+
         <div class="mt-3">
           <label for="input-string">Custom text</label>
           <input class="form-control mt-1 width-full" name="input-string" id="input-string" type="text">
@@ -105,7 +117,7 @@
       <div class="color-bg-default border rounded-2 p-3 mt-3">
         <div class="created-url border color-border-muted rounded-1 color-bg-subtle p-2 text-mono f6 wb-break-word">
           https://fakeimg.pl/<span id="width">600</span><span id="height">x400</span><span
-            id="bgcolour"></span><span id="textcolour"></span><span id="filetype"></span><span id="string"></span>
+            id="bgcolour"></span><span id="textcolour"></span><span id="filetype"></span><span id="string"><span id="font"></span></span>
         </div>
 
         <div class="d-flex flex-wrap mt-2">

--- a/index.html
+++ b/index.html
@@ -57,16 +57,6 @@
     <main class="flex-1">
       <div class="color-bg-default border rounded-2 p-3 mt-3">
         <div class="d-flex flex-items-center">
-          <label for="input-filetype" class="flex-1 mr-5">Filetype</label>
-          <select name="input-filetype" id="input-filetype" class="form-select flex-1" aria-label="Filetype">
-            <option value="png">PNG</option>
-            <option value="gif">GIF</option>
-            <option value="jpg">JPG</option>
-            <option value="jpeg">JPEG</option>
-          </select>
-        </div>
-
-        <div class="mt-3 d-flex flex-items-center">
           <label class="flex-1 mr-4" for="input-width">Width</label>
           <input class="flex-1 form-control width-full" name="input-width" id="input-width" type="number" value="600" min="1">
         </div>
@@ -117,7 +107,7 @@
       <div class="color-bg-default border rounded-2 p-3 mt-3">
         <div class="created-url border color-border-muted rounded-1 color-bg-subtle p-2 text-mono f6 wb-break-word">
           https://fakeimg.pl/<span id="width">600</span><span id="height">x400</span><span
-            id="bgcolour"></span><span id="textcolour"></span><span id="filetype"></span><span id="string"></span><span id="font"></span>
+            id="bgcolour"></span><span id="textcolour"></span><span id="string"></span><span id="font"></span>
         </div>
 
         <div class="d-flex flex-wrap mt-2">

--- a/js/main.js
+++ b/js/main.js
@@ -27,7 +27,6 @@ var $textcolour      = $('#textcolour');
 var $inputTextcolour = $('#input-textcolour');
 var $string          = $('#string');
 var $inputString     = $('#input-string');
-var $filetype        = $('#filetype');
 var $font            = $('#font');
 
 function updateColours() {
@@ -72,16 +71,10 @@ $inputString.on('change keydown paste', function () {
       var newStr = '?text=' + str.replace( /\s+/g, '+' );
       // Display string in URL
       $string.html( newStr );
-      // Update font value
     }
 
     updateFont();
   }, 0);
-});
-
-// Updates value for filetype every time a new option is selected
-$('#input-filetype').on('change', function () {
-  $filetype.html( '.' + $('#input-filetype').val() );
 });
 
 // Updates font value every time a new option is selected
@@ -139,16 +132,15 @@ $('.js-reset-button').click(function() {
     .removeAttr('checked')
     .removeAttr('selected');
   // Clear all the variable spans
-  $( '#bgcolour, #textcolour, #filetype, #string, #font' ).empty();
+  $( '#bgcolour, #textcolour, #string, #font' ).empty();
   $( '#width' ).text( '600');
   $( '#height' ).text( 'x400');
-  // Reset dimensions, colours, string, and filetype to defaults
+  // Reset dimensions, colours, string, and font to defaults
   $( '#input-width' ).val( '600' );
   $( '#input-height' ).val( '400' );
   $( '#input-bgcolour' ).val( '#cccccc' );
   $( '#input-textcolour' ).val( '#969696' );
   $( '#input-string' ).val( '' );
-  $( '#input-filetype' ).val( 'png' );
   $( '#input-font' ).val( 'yanone' );
   // Reset colour swatches
   $('#input-bgcolour').parent().find( '.minicolors-swatch-color' ).attr('style', 'background-color: rgb(204, 204, 204); opacity: 1;');

--- a/js/main.js
+++ b/js/main.js
@@ -28,6 +28,7 @@ var $inputTextcolour = $('#input-textcolour');
 var $string          = $('#string');
 var $inputString     = $('#input-string');
 var $filetype        = $('#filetype');
+var $font            = $('#font');
 
 function updateColours() {
   $bgcolour.html( '/' + $inputBgcolour.val().replace( '#', '' ) );
@@ -62,18 +63,44 @@ $inputTextcolour.on('change keydown paste', function () {
 // Updates value for string every time a key is entered in that field
 $inputString.on('change keydown paste', function () {
   setTimeout(function () {
-    // Change spaces for plus signs
     var str = $inputString.val();
-    var newStr = '?text=' + str.replace( /\s+/g, '+' );
-    // Display string in URL
-    $string.html( newStr );
+
+    if ( str == '' ) {
+      $string.empty();
+    } else {
+      // Change spaces for plus signs
+      var newStr = '?text=' + str.replace( /\s+/g, '+' );
+      // Display string in URL
+      $string.html( newStr );
+      // Update font value
+    }
+
+    updateFont();
   }, 0);
 });
 
-// Updates value for filetype every time a new radio button is clicked
+// Updates value for filetype every time a new option is selected
 $('#input-filetype').on('change', function () {
   $filetype.html( '.' + $('#input-filetype').val() );
 });
+
+// Updates font value every time a new option is selected
+$('#input-font').on('change', function () {
+  updateFont();
+});
+
+
+// Update the font value
+function updateFont() {
+  if ( $('#input-font').val() == 'yanone' ) {
+    $font.text( '' );
+  } else if ( $inputString.val() == '' ) {
+    $font.text( '?font=' + $('#input-font').val() );
+  } else {
+    $font.text( '&font=' + $('#input-font').val() );
+  }
+}
+
 
 // Instantiate clipboard.js
 var clipboard = new Clipboard('.js-copy-button', {
@@ -112,7 +139,7 @@ $('.js-reset-button').click(function() {
     .removeAttr('checked')
     .removeAttr('selected');
   // Clear all the variable spans
-  $( '#bgcolour, #textcolour, #filetype, #string' ).empty();
+  $( '#bgcolour, #textcolour, #filetype, #string, #font' ).empty();
   $( '#width' ).text( '600');
   $( '#height' ).text( 'x400');
   // Reset dimensions, colours, string, and filetype to defaults
@@ -122,6 +149,7 @@ $('.js-reset-button').click(function() {
   $( '#input-textcolour' ).val( '#969696' );
   $( '#input-string' ).val( '' );
   $( '#input-filetype' ).val( 'png' );
+  $( '#input-font' ).val( 'yanone' );
   // Reset colour swatches
   $('#input-bgcolour').parent().find( '.minicolors-swatch-color' ).attr('style', 'background-color: rgb(204, 204, 204); opacity: 1;');
   $('#input-textcolour').parent().find('.minicolors-swatch-color').attr('style', 'background-color: rgb(150, 150, 150); opacity: 1;');


### PR DESCRIPTION
Addresses some of the new features mentioned in https://github.com/dylanatsmith/betterplaceholder/issues/6.

- Add font option supporting the available fonts from https://github.com/Rydgel/Fake-images-please/tree/master/app/font
- Remove filetype option not supported by Fake Images Please
- Fix bug where entering and then removing custom text would not clear the URL param key

<img width="1438" alt="image" src="https://github.com/dylanatsmith/betterplaceholder/assets/6905903/eab9a24d-40eb-4177-892e-8091bca5533c">
